### PR TITLE
refactor: remove production deployment section and roadmap from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -171,25 +171,6 @@ pnpm run dev      # Servidor en http://localhost:5173
 - **Centro-derecha**: Posiciones moderadas con tendencia conservadora
 - **Derecha**: Contenido conservador y de derecha
 
-## 🌐 Despliegue en Producción
-
-### Con Docker Compose
-```bash
-# Producción
-docker-compose -f docker-compose.prod.yml up -d
-
-# Revisar logs
-docker-compose logs -f
-```
-
-### Variables de Entorno Producción
-```env
-NODE_ENV=production
-DATABASE_URL=postgresql://user:password@tu-db-host:5432/agora_db
-FRONTEND_URL=https://tu-dominio.com
-BACKEND_URL=https://api.tu-dominio.com
-```
-
 ## 🤝 Contribuir
 
 1. Fork el proyecto
@@ -198,29 +179,10 @@ BACKEND_URL=https://api.tu-dominio.com
 4. Push a la rama (`git push origin feature/AmazingFeature`)
 5. Abre un Pull Request
 
-## 📋 Roadmap
-
-- [ ] Sistema de preferencias avanzadas por temas
-- [ ] API pública para desarrolladores
-- [ ] Aplicación móvil (React Native)
-- [ ] Dashboard de administración
-- [ ] Métricas y analytics
-- [ ] Soporte para más países de LATAM
-- [ ] Sistema de notificaciones push
-- [ ] Chat/comentarios comunitarios
-
-## 📄 Licencia
-
-Este proyecto está bajo la Licencia MIT. Ver el archivo [LICENSE](LICENSE) para más detalles.
-
 ## 👥 Equipo
 
 - **Desarrollador Principal**: [@jul-cesar](https://github.com/jul-cesar)
-
-## 📞 Soporte
-
-- **Issues**: [GitHub Issues](https://github.com/jul-cesar/Agora/issues)
-- **Documentación**: [Wiki del Proyecto](https://github.com/jul-cesar/Agora/wiki)
+- **Desarrollador**: [@aks-alx](https://github.com/aks-alx)
 
 ---
 


### PR DESCRIPTION
This pull request primarily cleans up the `README.md` file by removing outdated or redundant sections related to production deployment, roadmap, license, and support. It also updates the team member list. These changes help streamline the documentation and keep it focused on contribution guidelines and core team information.

Documentation cleanup:

* Removed the "Despliegue en Producción" section, including Docker Compose instructions and production environment variables, to simplify the README and avoid duplication or outdated deployment details.
* Deleted the "Roadmap," "Licencia," and "Soporte" sections, removing checklists, license information, and support/contact links that are either covered elsewhere or no longer relevant.

Team update:

* Added a new developer, `@aks-alx`, to the "Equipo" section, ensuring team information is up to date.